### PR TITLE
Force dockerfile version number

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as build
-ARG VERSION=development
+ARG VERSION=1.0.5
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
So I really wanted Quay to use the version variable based in the makefile, but under further investigation - it doesn't seem like there's a great way to pass a version tag all the way to the dockerfile via quay programmability in an easy way.