### PR TITLE
[chore] Dockerfile to update SSL and Crypto packages for build time updates

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=1 go build -a -tags 'netgo osusergo static_build' -ldflags="-X m
 # alpine is used here as it seems to be the minimal image that passes quay.io vulnerability scan
 FROM alpine
 # update ssl packages for CVEs
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
+RUN apk update && apk add --upgrade libcrypto3 libssl3 && rm -rf /var/cache/apk/*
 COPY --from=build  /usr/local/bin/pure-fb-om-exporter /pure-fb-om-exporter
 
 # create an empty tokens file for use with volumes if required. You can use a mounted volume to /etc/pure-fb-om-exporter/ to pass the `tokens.yaml` file. File must be named `tokens.yaml`.


### PR DESCRIPTION
the previous command to update the SSL and Crypto packages did not seem to apply properly.

Currently there are 2 CVEs that are in the latest alpine image that can be resolved by updating the SSL and Crypto packages.

CVE-2023-6237

CVE-2023-6129

(sister FlashArray PR - https://github.com/PureStorage-OpenConnect/pure-fa-openmetrics-exporter/pull/103) 