### PR TITLE
Remove process_ and go_ debug metrics by default.

### DIFF
--- a/internal/openmetrics-exporter/collector.go
+++ b/internal/openmetrics-exporter/collector.go
@@ -2,9 +2,10 @@ package collectors
 
 import (
 	"context"
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
+	// "github.com/prometheus/client_golang/prometheus/collectors"
 )
 
 func Collector(ctx context.Context, metrics string, registry *prometheus.Registry, fbclient *client.FBClient) bool {
@@ -12,8 +13,8 @@ func Collector(ctx context.Context, metrics string, registry *prometheus.Registr
 	buckets := fbclient.GetBuckets()
 	arrayCollector := NewArraysCollector(fbclient)
 	registry.MustRegister(
-		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		collectors.NewGoCollector(),
+		// collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
+		// collectors.NewGoCollector(),
 		arrayCollector,
 	)
 	if metrics == "all" || metrics == "array" {


### PR DESCRIPTION
Remove process_ and go_ debug metrics by default.

If a customer, or developer is interested in these metrics they can comment out the required lines in collector.go and make their own build of the OME.

Now, it may be useful to tie is back to get --debug flag at some point, but right now i don't think this will required.