### PR TITLE
fix: fix grafana avg iops overview

### DIFF
--- a/extra/grafana/grafana-purefb-flashblade-overview.json
+++ b/extra/grafana/grafana-purefb-flashblade-overview.json
@@ -3177,6 +3177,6 @@
   "timezone": "",
   "title": "Pure Storage FlashBlade - Overview",
   "uid": "z0BG6-vVz",
-  "version": 217,
+  "version": 218,
   "weekStart": ""
 }

--- a/extra/grafana/grafana-purefb-flashblade-overview.json
+++ b/extra/grafana/grafana-purefb-flashblade-overview.json
@@ -61,7 +61,7 @@
       }
     ]
   },
-  "description": "v1.0.6 Fixes a bug with Grafana setting datasource \"uid\": \"${DS_PROMETHEUS}\" causing some user panels not to successfully load. Fix involves manually overriding with \"uid\": \"$datasource\".",
+  "description": "v1.0.6 Fix: Changes Average IOPS by IO Type and array(s) from Instant to Range to calculate average over range rather returning a single average value.",
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,

--- a/extra/grafana/grafana-purefb-flashblade-overview.json
+++ b/extra/grafana/grafana-purefb-flashblade-overview.json
@@ -1303,10 +1303,10 @@
           "exemplar": false,
           "expr": "sum(avg_over_time(purefb_array_performance_throughput_iops{instance=~\"$instance\",env=~\"$env\"}[$__range])) by (dimension)",
           "format": "time_series",
-          "instant": true,
+          "instant": false,
           "interval": "",
           "legendFormat": "__auto",
-          "range": false,
+          "range": true,
           "refId": "Average IOPS"
         }
       ],

--- a/extra/grafana/grafana-purefb-flashblade-overview.json
+++ b/extra/grafana/grafana-purefb-flashblade-overview.json
@@ -61,7 +61,7 @@
       }
     ]
   },
-  "description": "v1.0.5 Fixes a bug with Grafana setting datasource \"uid\": \"${DS_PROMETHEUS}\" causing some user panels not to successfully load. Fix involves manually overriding with \"uid\": \"$datasource\".",
+  "description": "v1.0.6 Fixes a bug with Grafana setting datasource \"uid\": \"${DS_PROMETHEUS}\" causing some user panels not to successfully load. Fix involves manually overriding with \"uid\": \"$datasource\".",
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -2954,8 +2954,8 @@
       {
         "current": {
           "selected": false,
-          "text": "1.0.5",
-          "value": "1.0.5"
+          "text": "1.0.6",
+          "value": "1.0.6"
         },
         "hide": 2,
         "includeAll": false,
@@ -2964,11 +2964,11 @@
         "options": [
           {
             "selected": true,
-            "text": "1.0.5",
-            "value": "1.0.5"
+            "text": "1.0.6",
+            "value": "1.0.6"
           }
         ],
-        "query": "1.0.5",
+        "query": "1.0.6",
         "skipUrlSync": false,
         "type": "custom"
       },


### PR DESCRIPTION
Currently the panel `Average IOPS by IO Type and $instance arrays(s)` is only showing instant data, which is not useful since will only show the last value. Changing the query to a `range` instead of `instant` will show the data with historical values for a better overview.

Current:
<img width="751" alt="image" src="https://github.com/PureStorage-OpenConnect/pure-fb-openmetrics-exporter/assets/44772900/70b3fc95-8089-4a3d-bed6-2dd5dfa68fd0">

With these changes:
<img width="753" alt="image" src="https://github.com/PureStorage-OpenConnect/pure-fb-openmetrics-exporter/assets/44772900/ac3956dc-bb4a-415c-a5b9-247407091cc3">
