### PR TITLE
Name only secure ciphers in main.go - SWEET32

### DIFF
--- a/cmd/fb-om-exporter/main.go
+++ b/cmd/fb-om-exporter/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
@@ -101,7 +102,25 @@ func main() {
 		metricsHandler(w, r)
 	})
 	if isFile(*cert) && isFile(*key) {
-		log.Fatal(http.ListenAndServeTLS(addr, *cert, *key, nil))
+
+		cfg := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			},
+		}
+
+		srv := &http.Server{
+			TLSConfig: cfg,
+			Addr:      addr,
+		}
+
+		log.Fatal(srv.ListenAndServeTLS(*cert, *key))
 	} else {
 		log.Fatal(http.ListenAndServe(addr, nil))
 	}


### PR DESCRIPTION
Increase TLS scurity when running in HTTPS mode by only using TLS1.2+ and naming only secure ciphers.

For more details see: https://github.com/PureStorage-OpenConnect/pure-fa-openmetrics-exporter/pull/158