### PR TITLE
Add secure mode to exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The exporter can be started in TLS mode (HTTPS, mutually exclusive with the HTTP
 
 ```shell
 
-usage: pure-fb-om-exporter [-h|--help] [-a|--address "<value>"] [-p|--port <integer>] [-d|--debug] [-s|--secire] [-t|--tokens <file>] [-c|--cert "<value>"] [-k|--key "<value>"]
+usage: pure-fb-om-exporter [-h|--help] [-a|--address "<value>"] [-p|--port <integer>] [-d|--debug] [-s|--secure] [-t|--tokens <file>] [-c|--cert "<value>"] [-k|--key "<value>"]
 
                            Pure Storage FB OpenMetrics exporter
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Arguments:
   -a  --address  IP address for this exporter to bind to. Default: 0.0.0.0
   -p  --port     Port for this exporter to listen. Default: 9491
   -d  --debug    Enable debug. Default: false
-  -s --secure    Enable TLS verification when connecting to array. Default: false
+  -s  --secure    Enable TLS verification when connecting to array. Default: false
   -t  --tokens   API token(s) map file
   -c  --cert     SSL/TLS certificate file. Required only for Exporter TLS
   -k  --key      SSL/TLS private key file. Required only for Exporter TLS

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The exporter can be started in TLS mode (HTTPS, mutually exclusive with the HTTP
 
 ```shell
 
-usage: pure-fb-om-exporter [-h|--help] [-a|--address "<value>"] [-p|--port <integer>] [-d|--debug] [-t|--tokens <file>] [-k|--key <file>] [-c|--cert <file>]
+usage: pure-fb-om-exporter [-h|--help] [-a|--address "<value>"] [-p|--port <integer>] [-d|--debug] [-s|--secire] [-t|--tokens <file>] [-c|--cert "<value>"] [-k|--key "<value>"]
 
                            Pure Storage FB OpenMetrics exporter
 
@@ -96,9 +96,10 @@ Arguments:
   -a  --address  IP address for this exporter to bind to. Default: 0.0.0.0
   -p  --port     Port for this exporter to listen. Default: 9491
   -d  --debug    Enable debug. Default: false
+  -s --secure    Enable TLS verification when connecting to array. Default: false
   -t  --tokens   API token(s) map file
-  -c  --cert     SSL/TLS certificate file. Required only for TLS
-  -k  --key      SSL/TLS private key file. Required only for TLS
+  -c  --cert     SSL/TLS certificate file. Required only for Exporter TLS
+  -k  --key      SSL/TLS private key file. Required only for Exporter TLS
 ```
 
 The array token configuration file must have to following syntax:

--- a/cmd/fb-om-exporter/main.go
+++ b/cmd/fb-om-exporter/main.go
@@ -106,7 +106,7 @@ func main() {
 			TLSConfig: cfg,
 			Addr:      addr,
 		}
-                http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
 			index(w, r)
 		})
@@ -199,7 +199,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	registry := prometheus.NewRegistry()
 	fbclient := client.NewRestClient(address, apitoken, apiver, uagent, debug, secure)
 	if fbclient.Error != nil {
-                log.Printf("[ERROR] %s %s %s %s FBCLIENT ERROR: %s\n", r.RemoteAddr, r.Method, r.URL, r.Header.Get("User-Agent"), fbclient.Error.Error())
+		log.Printf("[ERROR] %s %s %s %s FBCLIENT ERROR: %s\n", r.RemoteAddr, r.Method, r.URL, r.Header.Get("User-Agent"), fbclient.Error.Error())
 		http.Error(w, fbclient.Error.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/config/auth_tokens.go
+++ b/internal/config/auth_tokens.go
@@ -1,15 +1,15 @@
 package config
 
 type FlashBlade struct {
-        Address       string    `yaml:"address"`
-        ApiToken      string    `yaml:"api_token"`
+	Address  string `yaml:"address"`
+	ApiToken string `yaml:"api_token"`
 }
 
 type FlashBladeList map[string]FlashBlade
 
 func (f *FlashBladeList) GetArrayParams(fb string) (string, string) {
 	for a_name, a := range *f {
-                if a_name == fb {
+		if a_name == fb {
 			return a.Address, a.ApiToken
 		}
 	}

--- a/internal/openmetrics-exporter/alerts_collector_test.go
+++ b/internal/openmetrics-exporter/alerts_collector_test.go
@@ -51,7 +51,7 @@ func TestAlertsCollector(t *testing.T) {
 		alert := strings.Split(a, "\n")
 		want[fmt.Sprintf("label:{name:\"action\" value:\"%s\"} label:{name:\"code\" value:\"%s\"} label:{name:\"component_name\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} label:{name:\"created\" value:\"%s\"} label:{name:\"kburl\" value:\"%s\"} label:{name:\"severity\" value:\"%s\"} label:{name:\"summary\" value:\"%s\"} gauge:{value:%g}", alert[0], alert[1], alert[2], alert[3], alert[4], alert[5], alert[6], alert[7], n)] = true
 	}
-  c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+  c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	ac := NewAlertsCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/alerts_collector_test.go
+++ b/internal/openmetrics-exporter/alerts_collector_test.go
@@ -51,7 +51,7 @@ func TestAlertsCollector(t *testing.T) {
 		alert := strings.Split(a, "\n")
 		want[fmt.Sprintf("label:{name:\"action\" value:\"%s\"} label:{name:\"code\" value:\"%s\"} label:{name:\"component_name\" value:\"%s\"} label:{name:\"component_type\" value:\"%s\"} label:{name:\"created\" value:\"%s\"} label:{name:\"kburl\" value:\"%s\"} label:{name:\"severity\" value:\"%s\"} label:{name:\"summary\" value:\"%s\"} gauge:{value:%g}", alert[0], alert[1], alert[2], alert[3], alert[4], alert[5], alert[6], alert[7], n)] = true
 	}
-  c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	ac := NewAlertsCollector(c)
 	metricsCheck(t, ac, want)
 	server.Close()

--- a/internal/openmetrics-exporter/arrays_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-        "regexp"
-        "strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 func TestArraysCollector(t *testing.T) {
@@ -21,26 +20,26 @@ func TestArraysCollector(t *testing.T) {
 	var arrs client.ArraysList
 	json.Unmarshal(res, &arrs)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
 	want := make(map[string]bool)
-        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-        for _, a := range arrs.Items {
-                want[fmt.Sprintf("label:{name:\"array_name\" value:\"%s\"} label:{name:\"os\" value:\"%s\"} label:{name:\"system_id\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:1}", a.Name, a.Os, a.Id, a.Version)] = true
-        }
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+	for _, a := range arrs.Items {
+		want[fmt.Sprintf("label:{name:\"array_name\" value:\"%s\"} label:{name:\"os\" value:\"%s\"} label:{name:\"system_id\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:1}", a.Name, a.Os, a.Id, a.Version)] = true
+	}
 	ac := NewArraysCollector(c)
-        metricsCheck(t, ac, want)
-        server.Close()
+	metricsCheck(t, ac, want)
+	server.Close()
 }

--- a/internal/openmetrics-exporter/arrays_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_collector_test.go
@@ -36,7 +36,7 @@ func TestArraysCollector(t *testing.T) {
         endp := strings.Split(server.URL, "/")
         e := endp[len(endp)-1]
 	want := make(map[string]bool)
-        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
         for _, a := range arrs.Items {
                 want[fmt.Sprintf("label:{name:\"array_name\" value:\"%s\"} label:{name:\"os\" value:\"%s\"} label:{name:\"system_id\" value:\"%s\"} label:{name:\"version\" value:\"%s\"} gauge:{value:1}", a.Name, a.Os, a.Id, a.Version)] = true
         }

--- a/internal/openmetrics-exporter/arrays_http_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_http_perf_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type HttpPerfCollector struct {

--- a/internal/openmetrics-exporter/arrays_http_perf_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_http_perf_collector_test.go
@@ -36,7 +36,7 @@ func TestArraysHttpPerfCollector(t *testing.T) {
         endp := strings.Split(server.URL, "/")
         e := endp[len(endp)-1]
 	want := make(map[string]bool)
-        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
         for _, p := range arrs.Items {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"others_per_sec\"} gauge:{value:%g}", p.OthersPerSec)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"read_dirs_per_sec\"} gauge:{value:%g}", p.ReadDirsPerSec)] = true

--- a/internal/openmetrics-exporter/arrays_nfs_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_nfs_perf_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type NfsPerfCollector struct {

--- a/internal/openmetrics-exporter/arrays_nfs_perf_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_nfs_perf_collector_test.go
@@ -1,17 +1,16 @@
 package collectors
 
-
 import (
+	"encoding/json"
 	"fmt"
-	"testing"
-        "regexp"
-        "strings"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 func TestArraysNfsPerfCollector(t *testing.T) {
@@ -21,23 +20,23 @@ func TestArraysNfsPerfCollector(t *testing.T) {
 	var arrs client.ArraysNfsPerformanceList
 	json.Unmarshal(res, &arrs)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/nfs-specific-performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/nfs-specific-performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
 	want := make(map[string]bool)
-        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-        for _, p := range arrs.Items {
+	c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+	for _, p := range arrs.Items {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"fsinfos_per_sec\"} gauge:{value:%g}", p.FsinfosPerSec)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"fsstats_per_sec\"} gauge:{value:%g}", p.FsstatsPerSec)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"mkdirs_per_sec\"} gauge:{value:%g}", p.MkdirsPerSec)] = true
@@ -88,6 +87,6 @@ func TestArraysNfsPerfCollector(t *testing.T) {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"aggregate_file_metadata_creates_per_sec\"} gauge:{value:%g}", p.AggregateFileMetadataCreatesPerSec)] = true
 	}
 	ac := NewNfsPerfCollector(c)
-        metricsCheck(t, ac, want)
-        server.Close()
+	metricsCheck(t, ac, want)
+	server.Close()
 }

--- a/internal/openmetrics-exporter/arrays_nfs_perf_collector_test.go
+++ b/internal/openmetrics-exporter/arrays_nfs_perf_collector_test.go
@@ -36,7 +36,7 @@ func TestArraysNfsPerfCollector(t *testing.T) {
         endp := strings.Split(server.URL, "/")
         e := endp[len(endp)-1]
 	want := make(map[string]bool)
-        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+        c := client.NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
         for _, p := range arrs.Items {
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"fsinfos_per_sec\"} gauge:{value:%g}", p.FsinfosPerSec)] = true
 		want[fmt.Sprintf("label:{name:\"dimension\" value:\"fsstats_per_sec\"} gauge:{value:%g}", p.FsstatsPerSec)] = true

--- a/internal/openmetrics-exporter/arrays_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_perf_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type PerfCollector struct {

--- a/internal/openmetrics-exporter/arrays_perf_replication_collector.go
+++ b/internal/openmetrics-exporter/arrays_perf_replication_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type PerfReplicationCollector struct {

--- a/internal/openmetrics-exporter/arrays_s3_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_s3_perf_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type S3PerfCollector struct {

--- a/internal/openmetrics-exporter/buckets_s3_perf_collector.go
+++ b/internal/openmetrics-exporter/buckets_s3_perf_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type BucketsS3PerfCollector struct {

--- a/internal/openmetrics-exporter/clients_perf_collector.go
+++ b/internal/openmetrics-exporter/clients_perf_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type ClientsPerfCollector struct {

--- a/internal/openmetrics-exporter/file_systems_perf_collector.go
+++ b/internal/openmetrics-exporter/file_systems_perf_collector.go
@@ -1,8 +1,9 @@
 package collectors
 
 import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
 )
 
 type FileSystemsPerfCollector struct {

--- a/internal/openmetrics-exporter/hardware_collector.go
+++ b/internal/openmetrics-exporter/hardware_collector.go
@@ -1,9 +1,10 @@
 package collectors
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
 	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type HardwareCollector struct {

--- a/internal/openmetrics-exporter/nfs_policies_collector.go
+++ b/internal/openmetrics-exporter/nfs_policies_collector.go
@@ -1,14 +1,15 @@
 package collectors
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
 	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type NfsPoliciesCollector struct {
-	NfsPolicyDesc  *prometheus.Desc
-	Client         *client.FBClient
+	NfsPolicyDesc *prometheus.Desc
+	Client        *client.FBClient
 }
 
 func (c *NfsPoliciesCollector) Describe(ch chan<- *prometheus.Desc) {
@@ -19,7 +20,7 @@ func (c *NfsPoliciesCollector) Collect(ch chan<- prometheus.Metric) {
 	policies := c.Client.GetNFSExportPolicies()
 	if len(policies.Items) > 0 {
 		for _, pol := range policies.Items {
-		        for _, r := range pol.Rules {
+			for _, r := range pol.Rules {
 				auid := strconv.Itoa(r.AnonUid)
 				agid := strconv.Itoa(r.AnonGid)
 				sec := strconv.FormatBool(r.Secure)
@@ -40,13 +41,13 @@ func (c *NfsPoliciesCollector) Collect(ch chan<- prometheus.Metric) {
 }
 
 func NewNfsPoliciesCollector(fb *client.FBClient) *NfsPoliciesCollector {
-	return &NfsPoliciesCollector {
+	return &NfsPoliciesCollector{
 		NfsPolicyDesc: prometheus.NewDesc(
 			"purefb_nfs_export_rule",
 			"FlashBlade NFS export rule",
 			[]string{"policy", "client", "permission", "security", "access", "anon_uid", "anon_gid", "secure", "fid32", "atime", "index"},
 			prometheus.Labels{},
 		),
-		Client:      fb,
+		Client: fb,
 	}
 }

--- a/internal/openmetrics-exporter/usage_collector.go
+++ b/internal/openmetrics-exporter/usage_collector.go
@@ -1,9 +1,10 @@
 package collectors
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"purestorage/fb-openmetrics-exporter/internal/rest-client"
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
 	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type UsageCollector struct {

--- a/internal/rest-client/alerts_test.go
+++ b/internal/rest-client/alerts_test.go
@@ -44,7 +44,7 @@ func TestAlerts(t *testing.T) {
         endp := strings.Split(server.URL, "/")
         e := endp[len(endp)-1]
         t.Run("alerts_open", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    al := c.GetAlerts("state='open'")
 	    if diff := cmp.Diff(al.Items, aopen.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -52,7 +52,7 @@ func TestAlerts(t *testing.T) {
             }
         })
         t.Run("alerts_all", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    al := c.GetAlerts("")
 	    if diff := cmp.Diff(al.Items, aall.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/alerts_test.go
+++ b/internal/rest-client/alerts_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -23,41 +22,41 @@ func TestAlerts(t *testing.T) {
 	json.Unmarshal(ropen, &aopen)
 	json.Unmarshal(rall, &aall)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        urlall := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/alerts$`)
-	        urlopen := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/alerts\?filter=state%3D%27open%27$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
+		urlall := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/alerts$`)
+		urlopen := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/alerts\?filter=state%3D%27open%27$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(vers))
-                } else if urlopen.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urlopen.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(ropen))
-                } else if urlall.MatchString(r.URL.Path) {
+		} else if urlall.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(rall))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("alerts_open", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    al := c.GetAlerts("state='open'")
-	    if diff := cmp.Diff(al.Items, aopen.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        t.Run("alerts_all", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    al := c.GetAlerts("")
-	    if diff := cmp.Diff(al.Items, aall.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        server.Close()
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("alerts_open", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		al := c.GetAlerts("state='open'")
+		if diff := cmp.Diff(al.Items, aopen.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("alerts_all", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		al := c.GetAlerts("")
+		if diff := cmp.Diff(al.Items, aall.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	server.Close()
 }

--- a/internal/rest-client/arrays.go
+++ b/internal/rest-client/arrays.go
@@ -25,11 +25,11 @@ func (fb *FBClient) GetArrays() *ArraysList {
 	res, _ := fb.RestClient.R().
 		SetResult(&result).
 		Get(uri)
-        if res.StatusCode() == 401 {
-                fb.RefreshSession()
+	if res.StatusCode() == 401 {
+		fb.RefreshSession()
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/arrays_http_perf.go
+++ b/internal/rest-client/arrays_http_perf.go
@@ -29,10 +29,10 @@ func (fb *FBClient) GetArraysHttpPerformance() *ArraysHttpPerformanceList {
 		SetResult(&result).
 		Get(uri)
 	if res.StatusCode() == 401 {
-                fb.RefreshSession()
+		fb.RefreshSession()
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/arrays_http_perf_test.go
+++ b/internal/rest-client/arrays_http_perf_test.go
@@ -36,7 +36,7 @@ func TestArraysHttpPerformance(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("arrays_http_performance_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             ahpl := c.GetArraysHttpPerformance()
 	    if diff := cmp.Diff(ahpl.Items[0], arrhp.Items[0]); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_http_perf_test.go
+++ b/internal/rest-client/arrays_http_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestArraysHttpPerformance(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/arrays_http_performance.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var arrhp ArraysHttpPerformanceList
-        json.Unmarshal(res, &arrhp)
+	var arrhp ArraysHttpPerformanceList
+	json.Unmarshal(res, &arrhp)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/http-specific-performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/http-specific-performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("arrays_http_performance_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            ahpl := c.GetArraysHttpPerformance()
-	    if diff := cmp.Diff(ahpl.Items[0], arrhp.Items[0]); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("arrays_http_performance_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		ahpl := c.GetArraysHttpPerformance()
+		if diff := cmp.Diff(ahpl.Items[0], arrhp.Items[0]); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/arrays_nfs_perf.go
+++ b/internal/rest-client/arrays_nfs_perf.go
@@ -67,10 +67,10 @@ func (fb *FBClient) GetArraysNfsPerformance() *ArraysNfsPerformanceList {
 		SetResult(&result).
 		Get(uri)
 	if res.StatusCode() == 401 {
-                fb.RefreshSession()
+		fb.RefreshSession()
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/arrays_nfs_perf_test.go
+++ b/internal/rest-client/arrays_nfs_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestArraysNfsPerformance(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/arrays_nfs_performance.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var arrsp ArraysNfsPerformanceList
-        json.Unmarshal(res, &arrsp)
+	var arrsp ArraysNfsPerformanceList
+	json.Unmarshal(res, &arrsp)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/nfs-specific-performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/nfs-specific-performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("arrays_http_performance_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            apl := c.GetArraysNfsPerformance()
-	    if diff := cmp.Diff(apl.Items[0], arrsp.Items[0]); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("arrays_http_performance_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		apl := c.GetArraysNfsPerformance()
+		if diff := cmp.Diff(apl.Items[0], arrsp.Items[0]); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/arrays_nfs_perf_test.go
+++ b/internal/rest-client/arrays_nfs_perf_test.go
@@ -36,7 +36,7 @@ func TestArraysNfsPerformance(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("arrays_http_performance_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             apl := c.GetArraysNfsPerformance()
 	    if diff := cmp.Diff(apl.Items[0], arrsp.Items[0]); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_perf.go
+++ b/internal/rest-client/arrays_perf.go
@@ -16,11 +16,11 @@ func (fb *FBClient) GetArraysPerformance(protocol string) *ArraysPerformanceList
 			SetQueryParam("protocol", protocol).
 			Get(uri)
 		if res.StatusCode() == 401 {
-                	fb.RefreshSession()
+			fb.RefreshSession()
 			fb.RestClient.R().
-			        SetResult(&result).
-			        SetQueryParam("protocol", protocol).
-			        Get(uri)
+				SetResult(&result).
+				SetQueryParam("protocol", protocol).
+				Get(uri)
 		}
 	}
 	return result

--- a/internal/rest-client/arrays_perf_replication.go
+++ b/internal/rest-client/arrays_perf_replication.go
@@ -32,10 +32,10 @@ func (fb *FBClient) GetArraysPerformanceReplication() *ArraysPerformanceReplicat
 		SetResult(&result).
 		Get(uri)
 	if res.StatusCode() == 401 {
-                fb.RefreshSession()
+		fb.RefreshSession()
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/arrays_perf_replication_test.go
+++ b/internal/rest-client/arrays_perf_replication_test.go
@@ -1,18 +1,16 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
-
 
 func TestArraysPerformanceReplication(t *testing.T) {
 
@@ -21,28 +19,28 @@ func TestArraysPerformanceReplication(t *testing.T) {
 	var arrpr ArraysPerformanceReplicationList
 	json.Unmarshal(res, &arrpr)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance/replication$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance/replication$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
-	        }
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("array_performance_replication_1", func(t *testing.T) {
-	    defer server.Close()
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    aprl := c.GetArraysPerformanceReplication()
-	    if diff := cmp.Diff(aprl.Items, arrpr.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        server.Close()
+		}
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("array_performance_replication_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		aprl := c.GetArraysPerformanceReplication()
+		if diff := cmp.Diff(aprl.Items, arrpr.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	server.Close()
 }

--- a/internal/rest-client/arrays_perf_replication_test.go
+++ b/internal/rest-client/arrays_perf_replication_test.go
@@ -37,7 +37,7 @@ func TestArraysPerformanceReplication(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("array_performance_replication_1", func(t *testing.T) {
 	    defer server.Close()
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    aprl := c.GetArraysPerformanceReplication()
 	    if diff := cmp.Diff(aprl.Items, arrpr.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_perf_test.go
+++ b/internal/rest-client/arrays_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -32,83 +31,83 @@ func TestArraysPerformance(t *testing.T) {
 	json.Unmarshal(psmb, &asmb)
 	json.Unmarshal(ps3, &as3)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        urlall := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=all$`)
-	        urlhttp := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=HTTP$`)
-	        urlnfs := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=NFS$`)
-	        urlsmb := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=SMB$`)
-	        urls3 := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=S3$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
+		urlall := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=all$`)
+		urlhttp := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=HTTP$`)
+		urlnfs := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=NFS$`)
+		urlsmb := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=SMB$`)
+		urls3 := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/performance\?protocol=S3$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(vers))
-                } else if urlall.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urlall.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(pall))
-                } else if urlhttp.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urlhttp.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(phttp))
-                } else if urlnfs.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urlnfs.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(pnfs))
-                } else if urlsmb.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urlsmb.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(psmb))
-                } else if urls3.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urls3.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(ps3))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("array_perf_all", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    pl := c.GetArraysPerformance("all")
-	    if diff := cmp.Diff(pl.Items, aall.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        t.Run("array_perf_http", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    pl := c.GetArraysPerformance("HTTP")
-	    if diff := cmp.Diff(pl.Items, ahttp.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        t.Run("array_perf_nfs", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    pl := c.GetArraysPerformance("NFS")
-	    if diff := cmp.Diff(pl.Items, anfs.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        t.Run("array_perf_smb", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    pl := c.GetArraysPerformance("SMB")
-	    if diff := cmp.Diff(pl.Items, asmb.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        t.Run("array_perf_s3", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    pl := c.GetArraysPerformance("S3")
-	    if diff := cmp.Diff(pl.Items, as3.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        server.Close()
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("array_perf_all", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		pl := c.GetArraysPerformance("all")
+		if diff := cmp.Diff(pl.Items, aall.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("array_perf_http", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		pl := c.GetArraysPerformance("HTTP")
+		if diff := cmp.Diff(pl.Items, ahttp.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("array_perf_nfs", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		pl := c.GetArraysPerformance("NFS")
+		if diff := cmp.Diff(pl.Items, anfs.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("array_perf_smb", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		pl := c.GetArraysPerformance("SMB")
+		if diff := cmp.Diff(pl.Items, asmb.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("array_perf_s3", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		pl := c.GetArraysPerformance("S3")
+		if diff := cmp.Diff(pl.Items, as3.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	server.Close()
 }

--- a/internal/rest-client/arrays_perf_test.go
+++ b/internal/rest-client/arrays_perf_test.go
@@ -71,7 +71,7 @@ func TestArraysPerformance(t *testing.T) {
         endp := strings.Split(server.URL, "/")
         e := endp[len(endp)-1]
         t.Run("array_perf_all", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    pl := c.GetArraysPerformance("all")
 	    if diff := cmp.Diff(pl.Items, aall.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -79,7 +79,7 @@ func TestArraysPerformance(t *testing.T) {
             }
         })
         t.Run("array_perf_http", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    pl := c.GetArraysPerformance("HTTP")
 	    if diff := cmp.Diff(pl.Items, ahttp.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -87,7 +87,7 @@ func TestArraysPerformance(t *testing.T) {
             }
         })
         t.Run("array_perf_nfs", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    pl := c.GetArraysPerformance("NFS")
 	    if diff := cmp.Diff(pl.Items, anfs.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -95,7 +95,7 @@ func TestArraysPerformance(t *testing.T) {
             }
         })
         t.Run("array_perf_smb", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    pl := c.GetArraysPerformance("SMB")
 	    if diff := cmp.Diff(pl.Items, asmb.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -103,7 +103,7 @@ func TestArraysPerformance(t *testing.T) {
             }
         })
         t.Run("array_perf_s3", func(t *testing.T) {
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    pl := c.GetArraysPerformance("S3")
 	    if diff := cmp.Diff(pl.Items, as3.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_s3_perf.go
+++ b/internal/rest-client/arrays_s3_perf.go
@@ -17,6 +17,6 @@ func (fb *FBClient) GetArraysS3Performance() *ArraysS3PerformanceList {
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/arrays_s3_perf_test.go
+++ b/internal/rest-client/arrays_s3_perf_test.go
@@ -36,7 +36,7 @@ func TestArraysS3Performance(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("array_s3_specific_1", func(t *testing.T) {
             defer server.Close()
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    pl := c.GetArraysS3Performance()
 	    if diff := cmp.Diff(pl.Items, as3.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_s3_perf_test.go
+++ b/internal/rest-client/arrays_s3_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"encoding/json"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -20,26 +19,26 @@ func TestArraysS3Performance(t *testing.T) {
 	var as3 ArraysS3PerformanceList
 	json.Unmarshal(s3f, &as3)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        urls3 := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/s3-specific-performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
+		urls3 := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/s3-specific-performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(vers))
-                } else if urls3.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urls3.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(s3f))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("array_s3_specific_1", func(t *testing.T) {
-            defer server.Close()
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    pl := c.GetArraysS3Performance()
-	    if diff := cmp.Diff(pl.Items, as3.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("array_s3_specific_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		pl := c.GetArraysS3Performance()
+		if diff := cmp.Diff(pl.Items, as3.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/arrays_space_test.go
+++ b/internal/rest-client/arrays_space_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -19,62 +18,62 @@ func TestArraysSpace(t *testing.T) {
 	resfs, _ := os.ReadFile("../../test/data/arrays_space_file_system.json")
 	reso, _ := os.ReadFile("../../test/data/arrays_space_object_store.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var arrsa ArraysSpaceList
-        var arrsfs ArraysSpaceList
-        var arrso ArraysSpaceList
-        json.Unmarshal(resa, &arrsa)
-        json.Unmarshal(resfs, &arrsfs)
-        json.Unmarshal(reso, &arrso)
+	var arrsa ArraysSpaceList
+	var arrsfs ArraysSpaceList
+	var arrso ArraysSpaceList
+	json.Unmarshal(resa, &arrsa)
+	json.Unmarshal(resfs, &arrsfs)
+	json.Unmarshal(reso, &arrso)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        urla := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/space\?type=array$`)
-	        urlfs := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/space\?type=file-system$`)
-	        urlo := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/space\?type=object-store$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if urla.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		urla := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/space\?type=array$`)
+		urlfs := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/space\?type=file-system$`)
+		urlo := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/space\?type=object-store$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if urla.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(resa))
-                } else if urlfs.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urlfs.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(resfs))
-                } else if urlo.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
+		} else if urlo.MatchString(r.URL.Path + "?" + r.URL.RawQuery) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(reso))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("arrays_space_1", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            asl := c.GetArraysSpace("array")
-	    if diff := cmp.Diff(asl.Items, arrsa.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-                server.Close()
-            }
-        })
-        t.Run("arrays_space_2", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            asfs := c.GetArraysSpace("file-system")
-	    if diff := cmp.Diff(asfs.Items, arrsfs.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-                server.Close()
-            }
-        })
-        t.Run("arrays_space_3", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            aso := c.GetArraysSpace("object-store")
-	    if diff := cmp.Diff(aso.Items, arrso.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-                server.Close()
-            }
-        })
-        server.Close()
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("arrays_space_1", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		asl := c.GetArraysSpace("array")
+		if diff := cmp.Diff(asl.Items, arrsa.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("arrays_space_2", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		asfs := c.GetArraysSpace("file-system")
+		if diff := cmp.Diff(asfs.Items, arrsfs.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("arrays_space_3", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		aso := c.GetArraysSpace("object-store")
+		if diff := cmp.Diff(aso.Items, arrso.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	server.Close()
 }

--- a/internal/rest-client/arrays_space_test.go
+++ b/internal/rest-client/arrays_space_test.go
@@ -53,7 +53,7 @@ func TestArraysSpace(t *testing.T) {
         endp := strings.Split(server.URL, "/")
         e := endp[len(endp)-1]
         t.Run("arrays_space_1", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             asl := c.GetArraysSpace("array")
 	    if diff := cmp.Diff(asl.Items, arrsa.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -61,7 +61,7 @@ func TestArraysSpace(t *testing.T) {
             }
         })
         t.Run("arrays_space_2", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             asfs := c.GetArraysSpace("file-system")
 	    if diff := cmp.Diff(asfs.Items, arrsfs.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)
@@ -69,7 +69,7 @@ func TestArraysSpace(t *testing.T) {
             }
         })
         t.Run("arrays_space_3", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             aso := c.GetArraysSpace("object-store")
 	    if diff := cmp.Diff(aso.Items, arrso.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/arrays_test.go
+++ b/internal/rest-client/arrays_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestArraysInfo(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/arrays.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var arr ArraysList
-        json.Unmarshal(res, &arr)
+	var arr ArraysList
+	json.Unmarshal(res, &arr)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("arrays_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            al := c.GetArrays()
-	    if diff := cmp.Diff(al.Items, arr.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("arrays_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		al := c.GetArrays()
+		if diff := cmp.Diff(al.Items, arr.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/arrays_test.go
+++ b/internal/rest-client/arrays_test.go
@@ -36,7 +36,7 @@ func TestArraysInfo(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("arrays_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             al := c.GetArrays()
 	    if diff := cmp.Diff(al.Items, arr.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/blades_test.go
+++ b/internal/rest-client/blades_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestBlades(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/arrays.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var abl BladesList
-        json.Unmarshal(res, &abl)
+	var abl BladesList
+	json.Unmarshal(res, &abl)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/blades$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/blades$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("blades_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            bl := c.GetBlades()
-	    if diff := cmp.Diff(bl.Items, abl.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("blades_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		bl := c.GetBlades()
+		if diff := cmp.Diff(bl.Items, abl.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/blades_test.go
+++ b/internal/rest-client/blades_test.go
@@ -36,7 +36,7 @@ func TestBlades(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("blades_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             bl := c.GetBlades()
 	    if diff := cmp.Diff(bl.Items, abl.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/buckets_perf_test.go
+++ b/internal/rest-client/buckets_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -18,36 +17,36 @@ func TestBucketsPerformance(t *testing.T) {
 	bf, _ := os.ReadFile("../../test/data/buckets_for_perf.json")
 	bpf, _ := os.ReadFile("../../test/data/buckets_performance.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var bpl BucketsPerformanceList
-        json.Unmarshal(bpf, &bpl)
+	var bpl BucketsPerformanceList
+	json.Unmarshal(bpf, &bpl)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        buri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets$`)
-	        bpuri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets/performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if buri.MatchString(r.URL.Path) {
+		buri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets$`)
+		bpuri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets/performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if buri.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(bf))
-                } else if bpuri.MatchString(r.URL.Path) {
+		} else if bpuri.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(bpf))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("buckets_performance_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    b := c.GetBuckets()
-            pl := c.GetBucketsPerformance(b)
-	    if diff := cmp.Diff(pl.Items, bpl.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("buckets_performance_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		b := c.GetBuckets()
+		pl := c.GetBucketsPerformance(b)
+		if diff := cmp.Diff(pl.Items, bpl.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/buckets_perf_test.go
+++ b/internal/rest-client/buckets_perf_test.go
@@ -43,7 +43,7 @@ func TestBucketsPerformance(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("buckets_performance_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    b := c.GetBuckets()
             pl := c.GetBucketsPerformance(b)
 	    if diff := cmp.Diff(pl.Items, bpl.Items); diff != "" {

--- a/internal/rest-client/buckets_s3_perf_test.go
+++ b/internal/rest-client/buckets_s3_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -18,36 +17,36 @@ func TestBucketsS3Performance(t *testing.T) {
 	bf, _ := os.ReadFile("../../test/data/buckets_for_perf.json")
 	bpf, _ := os.ReadFile("../../test/data/buckets_s3performance.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var bpl BucketsS3PerformanceList
-        json.Unmarshal(bpf, &bpl)
+	var bpl BucketsS3PerformanceList
+	json.Unmarshal(bpf, &bpl)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        buri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets$`)
-	        bpuri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets/s3-specific-performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if buri.MatchString(r.URL.Path) {
+		buri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets$`)
+		bpuri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets/s3-specific-performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if buri.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(bf))
-                } else if bpuri.MatchString(r.URL.Path) {
+		} else if bpuri.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(bpf))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("buckets_s3_performance_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
-	    b := c.GetBuckets()
-            pl := c.GetBucketsS3Performance(b)
-	    if diff := cmp.Diff(pl.Items, bpl.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("buckets_s3_performance_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		b := c.GetBuckets()
+		pl := c.GetBucketsS3Performance(b)
+		if diff := cmp.Diff(pl.Items, bpl.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/buckets_test.go
+++ b/internal/rest-client/buckets_test.go
@@ -36,7 +36,7 @@ func TestBuckets(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("buckets_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             bl := c.GetBuckets()
 	    if diff := cmp.Diff(bl.Items, ab.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/buckets_test.go
+++ b/internal/rest-client/buckets_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestBuckets(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/buckets.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var ab BucketsList
-        json.Unmarshal(res, &ab)
+	var ab BucketsList
+	json.Unmarshal(res, &ab)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/buckets$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("buckets_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            bl := c.GetBuckets()
-	    if diff := cmp.Diff(bl.Items, ab.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("buckets_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		bl := c.GetBuckets()
+		if diff := cmp.Diff(bl.Items, ab.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/clients_perf.go
+++ b/internal/rest-client/clients_perf.go
@@ -30,10 +30,10 @@ func (fb *FBClient) GetClientsPerformance() *ClientsPerformanceList {
 		SetResult(&result).
 		Get(uri)
 	if res.StatusCode() == 401 {
-                fb.RefreshSession()
+		fb.RefreshSession()
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/clients_perf_test.go
+++ b/internal/rest-client/clients_perf_test.go
@@ -36,7 +36,7 @@ func TestClientsPerformance(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("clients_performance_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             cp := c.GetClientsPerformance()
 	    if diff := cmp.Diff(cp.Items, cpl.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/clients_perf_test.go
+++ b/internal/rest-client/clients_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestClientsPerformance(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/clients_performance.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var cpl ClientsPerformanceList
-        json.Unmarshal(res, &cpl)
+	var cpl ClientsPerformanceList
+	json.Unmarshal(res, &cpl)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/clients/performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/arrays/clients/performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("clients_performance_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            cp := c.GetClientsPerformance()
-	    if diff := cmp.Diff(cp.Items, cpl.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("clients_performance_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		cp := c.GetClientsPerformance()
+		if diff := cmp.Diff(cp.Items, cpl.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/filesystems_perf_test.go
+++ b/internal/rest-client/filesystems_perf_test.go
@@ -42,7 +42,7 @@ func TestFileSystemsPerformance(t *testing.T) {
         endp := strings.Split(server.URL, "/")
         e := endp[len(endp)-1]
         t.Run("filesystems_performance_all", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    f := c.GetFileSystems()
             fl := c.GetFileSystemsPerformance(f, "all")
 	    if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
@@ -51,7 +51,7 @@ func TestFileSystemsPerformance(t *testing.T) {
             }
         })
         t.Run("filesystems_performance_nfs", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    f := c.GetFileSystems()
             fl := c.GetFileSystemsPerformance(f, "NFS")
 	    if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
@@ -60,7 +60,7 @@ func TestFileSystemsPerformance(t *testing.T) {
             }
         })
         t.Run("filesystems_performance_smb", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
 	    f := c.GetFileSystems()
             fl := c.GetFileSystemsPerformance(f, "SMB")
 	    if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {

--- a/internal/rest-client/filesystems_perf_test.go
+++ b/internal/rest-client/filesystems_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -18,55 +17,55 @@ func TestFileSystemsPerformance(t *testing.T) {
 	ff, _ := os.ReadFile("../../test/data/filesystems_for_perf.json")
 	fpf, _ := os.ReadFile("../../test/data/filesystems_perf.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var fpl FileSystemsPerformanceList
-        json.Unmarshal(fpf, &fpl)
+	var fpl FileSystemsPerformanceList
+	json.Unmarshal(fpf, &fpl)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        furi := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/file-systems$`)
-	        fpuri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/file-systems/performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if furi.MatchString(r.URL.Path) {
+		furi := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/file-systems$`)
+		fpuri := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/file-systems/performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if furi.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(ff))
-                } else if fpuri.MatchString(r.URL.Path) {
+		} else if fpuri.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(fpf))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("filesystems_performance_all", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    f := c.GetFileSystems()
-            fl := c.GetFileSystemsPerformance(f, "all")
-	    if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        t.Run("filesystems_performance_nfs", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    f := c.GetFileSystems()
-            fl := c.GetFileSystemsPerformance(f, "NFS")
-	    if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        t.Run("filesystems_performance_smb", func(t *testing.T) {
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-	    f := c.GetFileSystems()
-            fl := c.GetFileSystemsPerformance(f, "SMB")
-	    if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-        	server.Close()
-            }
-        })
-        server.Close()
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("filesystems_performance_all", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		f := c.GetFileSystems()
+		fl := c.GetFileSystemsPerformance(f, "all")
+		if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("filesystems_performance_nfs", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		f := c.GetFileSystems()
+		fl := c.GetFileSystemsPerformance(f, "NFS")
+		if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	t.Run("filesystems_performance_smb", func(t *testing.T) {
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		f := c.GetFileSystems()
+		fl := c.GetFileSystemsPerformance(f, "SMB")
+		if diff := cmp.Diff(fl.Items, fpl.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+			server.Close()
+		}
+	})
+	server.Close()
 }

--- a/internal/rest-client/filesystems_test.go
+++ b/internal/rest-client/filesystems_test.go
@@ -35,7 +35,7 @@ func TestFileSystems(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("filesystems_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             fsl := c.GetFileSystems()
 	    if diff := cmp.Diff(fsl.Items, fs.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/filesystems_test.go
+++ b/internal/rest-client/filesystems_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -16,29 +15,29 @@ import (
 func TestFileSystems(t *testing.T) {
 	res, _ := os.ReadFile("../../test/data/filesystems.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var fs FileSystemsList
-        json.Unmarshal(res, &fs)
+	var fs FileSystemsList
+	json.Unmarshal(res, &fs)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/file-systems$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/file-systems$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("filesystems_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            fsl := c.GetFileSystems()
-	    if diff := cmp.Diff(fsl.Items, fs.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("filesystems_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		fsl := c.GetFileSystems()
+		if diff := cmp.Diff(fsl.Items, fs.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/flashblade_client.go
+++ b/internal/rest-client/flashblade_client.go
@@ -42,7 +42,7 @@ type FBClient struct {
 	Error      error
 }
 
-func NewRestClient(endpoint string, apitoken string, apiversion string, uagent string, debug bool) *FBClient {
+func NewRestClient(endpoint string, apitoken string, apiversion string, uagent string, debug bool, secure bool) *FBClient {
 	type ApiVersions struct {
 		Versions []string `json:"versions"`
 	}
@@ -53,7 +53,9 @@ func NewRestClient(endpoint string, apitoken string, apiversion string, uagent s
 		XAuthToken: "",
 	}
 	fb.RestClient.SetBaseURL("https://" + endpoint + "/api")
-	fb.RestClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	if !secure {
+		fb.RestClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	}
 	fb.RestClient.SetHeaders(map[string]string{
 		"Content-Type": "application/json",
 		"Accept":       "application/json",

--- a/internal/rest-client/flashblade_client_test.go
+++ b/internal/rest-client/flashblade_client_test.go
@@ -30,7 +30,7 @@ func TestNewRestClient(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("login", func(t *testing.T) {
             defer server.Close()
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             if c.EndPoint != e || c.ApiToken != "fake-api-token" || c.XAuthToken != "faketoken" {
                 t.Errorf("expected (%s, fake-api-token, faketoken), got (%s %s %s)", e, c.EndPoint, c.ApiToken, c.XAuthToken)
             }

--- a/internal/rest-client/flashblade_client_test.go
+++ b/internal/rest-client/flashblade_client_test.go
@@ -1,20 +1,19 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
+	"strings"
+	"testing"
 )
 
 func TestNewRestClient(t *testing.T) {
 
 	vers, _ := os.ReadFile("../../test/data/versions.json")
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/login$`)
+		valid := regexp.MustCompile(`^/api/login$`)
 		if r.URL.Path == "/api/api_version" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -25,14 +24,14 @@ func TestNewRestClient(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"items":[{"username":"fakeuser"}]}`))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("login", func(t *testing.T) {
-            defer server.Close()
-            c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            if c.EndPoint != e || c.ApiToken != "fake-api-token" || c.XAuthToken != "faketoken" {
-                t.Errorf("expected (%s, fake-api-token, faketoken), got (%s %s %s)", e, c.EndPoint, c.ApiToken, c.XAuthToken)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("login", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		if c.EndPoint != e || c.ApiToken != "fake-api-token" || c.XAuthToken != "faketoken" {
+			t.Errorf("expected (%s, fake-api-token, faketoken), got (%s %s %s)", e, c.EndPoint, c.ApiToken, c.XAuthToken)
+		}
+	})
 }

--- a/internal/rest-client/hardware.go
+++ b/internal/rest-client/hardware.go
@@ -28,10 +28,10 @@ func (fb *FBClient) GetHardware() *HardwareList {
 		SetResult(&result).
 		Get(uri)
 	if res.StatusCode() == 401 {
-                fb.RefreshSession()
+		fb.RefreshSession()
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/hardware_connectors_perf.go
+++ b/internal/rest-client/hardware_connectors_perf.go
@@ -37,10 +37,10 @@ func (fb *FBClient) GetHwConnectorsPerformance() *HwConnectorsPerformanceList {
 		SetResult(&result).
 		Get(uri)
 	if res.StatusCode() == 401 {
-                fb.RefreshSession()
+		fb.RefreshSession()
 		fb.RestClient.R().
 			SetResult(&result).
 			Get(uri)
-        }
+	}
 	return result
 }

--- a/internal/rest-client/hardware_connectors_perf_test.go
+++ b/internal/rest-client/hardware_connectors_perf_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestHwConnectorsPerformance(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/hw_connectors_perf.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var hw *HwConnectorsPerformanceList
-        json.Unmarshal(res, &hw)
+	var hw *HwConnectorsPerformanceList
+	json.Unmarshal(res, &hw)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/hardware-connectors/performance$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/hardware-connectors/performance$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("hardware_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            hl := c.GetHwConnectorsPerformance()
-	    if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("hardware_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		hl := c.GetHwConnectorsPerformance()
+		if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/hardware_connectors_perf_test.go
+++ b/internal/rest-client/hardware_connectors_perf_test.go
@@ -36,7 +36,7 @@ func TestHwConnectorsPerformance(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("hardware_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             hl := c.GetHwConnectorsPerformance()
 	    if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hardware_test.go
+++ b/internal/rest-client/hardware_test.go
@@ -36,7 +36,7 @@ func TestHardware(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("hardware_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             hl := c.GetHardware()
 	    if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)

--- a/internal/rest-client/hardware_test.go
+++ b/internal/rest-client/hardware_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestHardware(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/hardware.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var hw HardwareList
-        json.Unmarshal(res, &hw)
+	var hw HardwareList
+	json.Unmarshal(res, &hw)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/hardware$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/hardware$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("hardware_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            hl := c.GetHardware()
-	    if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("hardware_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		hl := c.GetHardware()
+		if diff := cmp.Diff(hl.Items, hw.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/nfs_export_policies.go
+++ b/internal/rest-client/nfs_export_policies.go
@@ -1,56 +1,56 @@
 package client
 
 type ExportRulePolicy struct {
-	Name             string    `json:"name"`
-	Id               string    `json:"id"`
-        ResourceType     string    `json:"resource_type"`
+	Name         string `json:"name"`
+	Id           string `json:"id"`
+	ResourceType string `json:"resource_type"`
 }
 
 type NFSExportRule struct {
-	Name             string            `json:"name"`
-	Id               string            `json:"id"`
-	Policy           ExportRulePolicy  `json:"policy"`
-	Index            int               `json:"index"`
-	PolicyVersion    string            `json:"policy_version"`
-	Access           string            `json:"access"`
-	AnonGid          int               `json:"anongid"`
-	AnonUid          int               `json:"anonuid"`
-        Atime            bool              `json:"atime"`
-	Client           string            `json:"client"`
-        FileId32bit      bool              `json:"fileid_32bit"`
-	Permission       string            `json:"permission"`
-        Secure           bool              `json:"secure"`
-        Security         []string          `json:"security"`
+	Name          string           `json:"name"`
+	Id            string           `json:"id"`
+	Policy        ExportRulePolicy `json:"policy"`
+	Index         int              `json:"index"`
+	PolicyVersion string           `json:"policy_version"`
+	Access        string           `json:"access"`
+	AnonGid       int              `json:"anongid"`
+	AnonUid       int              `json:"anonuid"`
+	Atime         bool             `json:"atime"`
+	Client        string           `json:"client"`
+	FileId32bit   bool             `json:"fileid_32bit"`
+	Permission    string           `json:"permission"`
+	Secure        bool             `json:"secure"`
+	Security      []string         `json:"security"`
 }
 
 type NFSExportPolicy struct {
-	Name             string            `json:"name"`
-	Id               string            `json:"id"`
-        Enabled          bool              `json:"enabled"`
-        IsLocal          bool              `json:"is_local"`
-        Location         Location          `json:"location"`
-        Version          string            `json:"version"`
-        Rules            []NFSExportRule   `json:"rules"`
-        PolicyType       string            `json:"policy_type"`
+	Name       string          `json:"name"`
+	Id         string          `json:"id"`
+	Enabled    bool            `json:"enabled"`
+	IsLocal    bool            `json:"is_local"`
+	Location   Location        `json:"location"`
+	Version    string          `json:"version"`
+	Rules      []NFSExportRule `json:"rules"`
+	PolicyType string          `json:"policy_type"`
 }
 
 type NFSExportPolicyList struct {
-	CntToken     string             `json:"continuation_token"`
-	TotalItemCnt int                `json:"total_item_count"`
-	Items        []NFSExportPolicy  `json:"items"`
+	CntToken     string            `json:"continuation_token"`
+	TotalItemCnt int               `json:"total_item_count"`
+	Items        []NFSExportPolicy `json:"items"`
 }
 
 func (fb *FBClient) GetNFSExportPolicies() *NFSExportPolicyList {
-        uri := "/nfs-export-policies"
+	uri := "/nfs-export-policies"
 	result := new(NFSExportPolicyList)
 	res, _ := fb.RestClient.R().
-	        SetResult(&result).
-	        Get(uri)
+		SetResult(&result).
+		Get(uri)
 	if res.StatusCode() == 401 {
 		fb.RefreshSession()
 		fb.RestClient.R().
-		        SetResult(&result).
-		        Get(uri)
+			SetResult(&result).
+			Get(uri)
 	}
 	return result
 }

--- a/internal/rest-client/nfs_export_policies_test.go
+++ b/internal/rest-client/nfs_export_policies_test.go
@@ -1,14 +1,13 @@
 package client
 
-
 import (
-	"testing"
-        "regexp"
-        "strings"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-        "encoding/json"
-        "os"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -17,29 +16,29 @@ func TestNFSExportPolicies(t *testing.T) {
 
 	res, _ := os.ReadFile("../../test/data/nfs_export_policies.json")
 	vers, _ := os.ReadFile("../../test/data/versions.json")
-        var nfsp NFSExportPolicyList
-        json.Unmarshal(res, &nfsp)
+	var nfsp NFSExportPolicyList
+	json.Unmarshal(res, &nfsp)
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	        valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/nfs-export-policies$`)
-                if r.URL.Path == "/api/api_version" {
-                        w.Header().Set("Content-Type", "application/json")
-                        w.WriteHeader(http.StatusOK)
-                        w.Write([]byte(vers))
-                } else if valid.MatchString(r.URL.Path) {
+		valid := regexp.MustCompile(`^/api/([0-9]+.[0-9]+)?/nfs-export-policies$`)
+		if r.URL.Path == "/api/api_version" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(vers))
+		} else if valid.MatchString(r.URL.Path) {
 			w.Header().Set("x-auth-token", "faketoken")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(res))
 		}
-	   }))
-        endp := strings.Split(server.URL, "/")
-        e := endp[len(endp)-1]
-        t.Run("nfs_policies_1", func(t *testing.T) {
-            defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
-            pl := c.GetNFSExportPolicies()
-	    if diff := cmp.Diff(pl.Items, nfsp.Items); diff != "" {
-                t.Errorf("Mismatch (-want +got):\n%s", diff)
-            }
-        })
+	}))
+	endp := strings.Split(server.URL, "/")
+	e := endp[len(endp)-1]
+	t.Run("nfs_policies_1", func(t *testing.T) {
+		defer server.Close()
+		c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
+		pl := c.GetNFSExportPolicies()
+		if diff := cmp.Diff(pl.Items, nfsp.Items); diff != "" {
+			t.Errorf("Mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/internal/rest-client/nfs_export_policies_test.go
+++ b/internal/rest-client/nfs_export_policies_test.go
@@ -36,7 +36,7 @@ func TestNFSExportPolicies(t *testing.T) {
         e := endp[len(endp)-1]
         t.Run("nfs_policies_1", func(t *testing.T) {
             defer server.Close()
-	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false)
+	    c := NewRestClient(e, "fake-api-token", "latest", "test-user-agent-string", false, false)
             pl := c.GetNFSExportPolicies()
 	    if diff := cmp.Diff(pl.Items, nfsp.Items); diff != "" {
                 t.Errorf("Mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
Currently all calls from the exporter to the array are secure via tls, but not checked for the validity.

This will use the system cert store to validate if the array should be trusted or not.

Closes #78 