### PR TITLE
[fix] Array metrics are included in the /objectstore endpoint scrape

### DIFF
--- a/cmd/fb-om-exporter/main.go
+++ b/cmd/fb-om-exporter/main.go
@@ -179,7 +179,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 		metrics = path[2]
 		switch metrics {
 		case "array":
-		case "buckets":
+		case "objectstore":
 		case "clients":
 		case "filesystems":
 		case "usage":


### PR DESCRIPTION
Fixes #93 