### PR TITLE
change describe blocks to use existing descriptions

### DIFF
--- a/internal/openmetrics-exporter/alerts_collector.go
+++ b/internal/openmetrics-exporter/alerts_collector.go
@@ -14,7 +14,7 @@ type AlertsCollector struct {
 }
 
 func (c *AlertsCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.AlertsDesc
 }
 
 func (c *AlertsCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/arrays_http_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_http_perf_collector.go
@@ -13,7 +13,8 @@ type HttpPerfCollector struct {
 }
 
 func (c *HttpPerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
 }
 
 func (c *HttpPerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/arrays_nfs_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_nfs_perf_collector.go
@@ -13,7 +13,8 @@ type NfsPerfCollector struct {
 }
 
 func (c *NfsPerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
 }
 
 func (c *NfsPerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/arrays_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_perf_collector.go
@@ -15,7 +15,10 @@ type PerfCollector struct {
 }
 
 func (c *PerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
+	ch <- c.BandwidthDesc
+	ch <- c.AverageSizeDesc
 }
 
 func (c *PerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/arrays_perf_replication_collector.go
+++ b/internal/openmetrics-exporter/arrays_perf_replication_collector.go
@@ -12,7 +12,7 @@ type PerfReplicationCollector struct {
 }
 
 func (c *PerfReplicationCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.ThroughputDesc
 }
 
 func (c *PerfReplicationCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/arrays_s3_perf_collector.go
+++ b/internal/openmetrics-exporter/arrays_s3_perf_collector.go
@@ -13,7 +13,8 @@ type S3PerfCollector struct {
 }
 
 func (c *S3PerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
 }
 
 func (c *S3PerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/arrays_space_collector.go
+++ b/internal/openmetrics-exporter/arrays_space_collector.go
@@ -15,7 +15,10 @@ type ArraySpaceCollector struct {
 }
 
 func (c *ArraySpaceCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.ReductionDesc
+	ch <- c.SpaceDesc
+	ch <- c.UtilizationDesc
+	ch <- c.ParityDesc
 }
 
 func (c *ArraySpaceCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/buckets_perf_collector.go
+++ b/internal/openmetrics-exporter/buckets_perf_collector.go
@@ -16,7 +16,10 @@ type BucketsPerfCollector struct {
 }
 
 func (c *BucketsPerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
+	ch <- c.BandwidthDesc
+	ch <- c.AverageSizeDesc
 }
 
 func (c *BucketsPerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/buckets_s3_perf_collector.go
+++ b/internal/openmetrics-exporter/buckets_s3_perf_collector.go
@@ -7,16 +7,15 @@ import (
 )
 
 type BucketsS3PerfCollector struct {
-	LatencyDesc     *prometheus.Desc
-	ThroughputDesc  *prometheus.Desc
-	BandwidthDesc   *prometheus.Desc
-	AverageSizeDesc *prometheus.Desc
-	Client          *client.FBClient
-	Buckets         *client.BucketsList
+	LatencyDesc    *prometheus.Desc
+	ThroughputDesc *prometheus.Desc
+	Client         *client.FBClient
+	Buckets        *client.BucketsList
 }
 
 func (c *BucketsS3PerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
 }
 
 func (c *BucketsS3PerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/buckets_space_collector.go
+++ b/internal/openmetrics-exporter/buckets_space_collector.go
@@ -17,7 +17,10 @@ type BucketsSpaceCollector struct {
 }
 
 func (c *BucketsSpaceCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.ReductionDesc
+	ch <- c.SpaceDesc
+	ch <- c.BucketQuotaDesc
+	ch <- c.BucketObjectCountDesc
 }
 
 func (c *BucketsSpaceCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/clients_perf_collector.go
+++ b/internal/openmetrics-exporter/clients_perf_collector.go
@@ -15,7 +15,10 @@ type ClientsPerfCollector struct {
 }
 
 func (c *ClientsPerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
+	ch <- c.BandwidthDesc
+	ch <- c.AverageSizeDesc
 }
 
 func (c *ClientsPerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/file_systems_perf_collector.go
+++ b/internal/openmetrics-exporter/file_systems_perf_collector.go
@@ -16,7 +16,10 @@ type FileSystemsPerfCollector struct {
 }
 
 func (c *FileSystemsPerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.LatencyDesc
+	ch <- c.ThroughputDesc
+	ch <- c.BandwidthDesc
+	ch <- c.AverageSizeDesc
 }
 
 func (c *FileSystemsPerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/file_systems_space_collector.go
+++ b/internal/openmetrics-exporter/file_systems_space_collector.go
@@ -14,7 +14,8 @@ type FileSystemsSpaceCollector struct {
 }
 
 func (c *FileSystemsSpaceCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.ReductionDesc
+	ch <- c.SpaceDesc
 }
 
 func (c *FileSystemsSpaceCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/hardware_collector.go
+++ b/internal/openmetrics-exporter/hardware_collector.go
@@ -13,7 +13,7 @@ type HardwareCollector struct {
 }
 
 func (c *HardwareCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.HardwareDesc
 }
 
 func (c *HardwareCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/hardware_connectors_perf_collector.go
+++ b/internal/openmetrics-exporter/hardware_connectors_perf_collector.go
@@ -14,7 +14,9 @@ type HwConnectorsPerfCollector struct {
 }
 
 func (c *HwConnectorsPerfCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.ThroughputDesc
+	ch <- c.BandwidthDesc
+	ch <- c.ErrorsDesc
 }
 
 func (c *HwConnectorsPerfCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/nfs_policies_collector.go
+++ b/internal/openmetrics-exporter/nfs_policies_collector.go
@@ -13,7 +13,7 @@ type NfsPoliciesCollector struct {
 }
 
 func (c *NfsPoliciesCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.NfsPolicyDesc
 }
 
 func (c *NfsPoliciesCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/object_store_accounts_collector.go
+++ b/internal/openmetrics-exporter/object_store_accounts_collector.go
@@ -14,7 +14,9 @@ type ObjectStoreAccountsCollector struct {
 }
 
 func (c *ObjectStoreAccountsCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.ReductionDesc
+	ch <- c.SpaceDesc
+	ch <- c.ObjectCountDesc
 }
 
 func (c *ObjectStoreAccountsCollector) Collect(ch chan<- prometheus.Metric) {

--- a/internal/openmetrics-exporter/usage_collector.go
+++ b/internal/openmetrics-exporter/usage_collector.go
@@ -15,7 +15,8 @@ type UsageCollector struct {
 }
 
 func (c *UsageCollector) Describe(ch chan<- *prometheus.Desc) {
-	prometheus.DescribeByCollect(c, ch)
+	ch <- c.UsageUsersDesc
+	ch <- c.UsageGroupsDesc
 }
 
 func (c *UsageCollector) Collect(ch chan<- prometheus.Metric) {


### PR DESCRIPTION
This modifies the way the Prometheus collects the descriptions of the metrics. On all of the collectors except the `ArraysCollector`, it was previously using the `DescribeByCollect` function. This function runs the `Collect` call to generate the descriptions.

Since the metrics returned are both static (the same set of metrics is always returned regardless of the FlashBlade being targeted), and expensive (each HTTP GET call has a not-insignificant time required to complete). I think it should instead statically assign the descriptions. This cuts the HTTP calls in half and results in about half of the time to run a collect.

There were also 2 metric descriptions in `internal/openmetrics-exporter/buckets_s3_perf_collector.go` that appear to have been left over from splitting it off from the overall bucket metrics. These never had any metrics published to them, so I removed them.