### PR TITLE
[Request] Add arm64 to matrix build/publish arch target list.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
         goos: [linux, windows]
-        goarch: [amd64]
+        goarch: [amd64, arm64]
     steps:
     - uses: actions/checkout@v4
     - uses: wangyoucao577/go-release-action@v1


### PR DESCRIPTION
Adds `arm64` to the list of GHA build/release target architecture.