### PR TITLE
Add a filter to not query destroyed buckets in GET /buckets

### DIFF
--- a/internal/rest-client/buckets.go
+++ b/internal/rest-client/buckets.go
@@ -44,7 +44,7 @@ type BucketsList struct {
 }
 
 func (fb *FBClient) GetBuckets() *BucketsList {
-	uri := "/buckets"
+	uri := "/buckets?destroyed=false"
 	result := new(BucketsList)
 	res, _ := fb.RestClient.R().
 		SetResult(&result).

--- a/internal/rest-client/buckets.go
+++ b/internal/rest-client/buckets.go
@@ -44,10 +44,11 @@ type BucketsList struct {
 }
 
 func (fb *FBClient) GetBuckets() *BucketsList {
-	uri := "/buckets?destroyed=false"
+	uri := "/buckets"
 	result := new(BucketsList)
 	res, _ := fb.RestClient.R().
 		SetResult(&result).
+		SetQueryParam("destroyed", "false").
 		Get(uri)
 	if res.StatusCode() == 401 {
 		fb.RefreshSession()


### PR DESCRIPTION
closes #108 

Currently GET /buckets gets a list of all buckets no matter if they're in the purgatory "destroyed, but not yet eradicated" state. The problem with this is, is that some further calls that we make that are based off of that list (eg. bucket performance) will not return a result if we ask for a destroyed bucket. 

This is the simplest way to fix this, as one a bucket is deleted - it immediately SHOULD immediately disappear from any o11y platform as that would be the indicator that "something is wrong", and still give you the eradication time to undo the deletion, if desired. 