### PR TITLE
Add support for SMB perf metrics and chunk enhancements

### DIFF
--- a/internal/openmetrics-exporter/file_systems_perf_collector.go
+++ b/internal/openmetrics-exporter/file_systems_perf_collector.go
@@ -23,78 +23,81 @@ func (c *FileSystemsPerfCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *FileSystemsPerfCollector) Collect(ch chan<- prometheus.Metric) {
-	filesystemsperf := c.Client.GetFileSystemsPerformance(c.FileSystems, "NFS")
-	if len(filesystemsperf.Items) == 0 {
+	if len(c.FileSystems.Items) == 0 {
 		return
 	}
 
-	for _, fp := range filesystemsperf.Items {
-		ch <- prometheus.MustNewConstMetric(
-			c.LatencyDesc,
-			prometheus.GaugeValue,
-			fp.UsecPerOtherOp,
-			fp.Name, "usec_per_other_op",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.LatencyDesc,
-			prometheus.GaugeValue,
-			fp.UsecPerReadOp,
-			fp.Name, "usec_per_read_op",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.LatencyDesc,
-			prometheus.GaugeValue,
-			fp.UsecPerWriteOp,
-			fp.Name, "usec_per_write_op",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.ThroughputDesc,
-			prometheus.GaugeValue,
-			fp.OthersPerSec,
-			fp.Name, "others_per_sec",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.ThroughputDesc,
-			prometheus.GaugeValue,
-			fp.ReadsPerSec,
-			fp.Name, "reads_per_sec",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.ThroughputDesc,
-			prometheus.GaugeValue,
-			fp.WritesPerSec,
-			fp.Name, "writes_per_sec",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.BandwidthDesc,
-			prometheus.GaugeValue,
-			fp.ReadBytesPerSec,
-			fp.Name, "read_bytes_per_sec",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.BandwidthDesc,
-			prometheus.GaugeValue,
-			fp.WriteBytesPerSec,
-			fp.Name, "write_bytes_per_sec",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.AverageSizeDesc,
-			prometheus.GaugeValue,
-			fp.BytesPerOp,
-			fp.Name, "bytes_per_op",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.AverageSizeDesc,
-			prometheus.GaugeValue,
-			fp.BytesPerRead,
-			fp.Name, "bytes_per_read",
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.AverageSizeDesc,
-			prometheus.GaugeValue,
-			fp.BytesPerWrite,
-			fp.Name, "bytes_per_write",
-		)
+	protocols := []string{"all", "SMB", "NFS"}
+	for _, proto := range protocols {
+		filesystemsperf := c.Client.GetFileSystemsPerformance(c.FileSystems, proto)
+		for _, fp := range filesystemsperf.Items {
+			ch <- prometheus.MustNewConstMetric(
+				c.LatencyDesc,
+				prometheus.GaugeValue,
+				fp.UsecPerOtherOp,
+				fp.Name, "usec_per_other_op", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.LatencyDesc,
+				prometheus.GaugeValue,
+				fp.UsecPerReadOp,
+				fp.Name, "usec_per_read_op", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.LatencyDesc,
+				prometheus.GaugeValue,
+				fp.UsecPerWriteOp,
+				fp.Name, "usec_per_write_op", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.ThroughputDesc,
+				prometheus.GaugeValue,
+				fp.OthersPerSec,
+				fp.Name, "others_per_sec", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.ThroughputDesc,
+				prometheus.GaugeValue,
+				fp.ReadsPerSec,
+				fp.Name, "reads_per_sec", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.ThroughputDesc,
+				prometheus.GaugeValue,
+				fp.WritesPerSec,
+				fp.Name, "writes_per_sec", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.BandwidthDesc,
+				prometheus.GaugeValue,
+				fp.ReadBytesPerSec,
+				fp.Name, "read_bytes_per_sec", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.BandwidthDesc,
+				prometheus.GaugeValue,
+				fp.WriteBytesPerSec,
+				fp.Name, "write_bytes_per_sec", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.AverageSizeDesc,
+				prometheus.GaugeValue,
+				fp.BytesPerOp,
+				fp.Name, "bytes_per_op", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.AverageSizeDesc,
+				prometheus.GaugeValue,
+				fp.BytesPerRead,
+				fp.Name, "bytes_per_read", proto,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.AverageSizeDesc,
+				prometheus.GaugeValue,
+				fp.BytesPerWrite,
+				fp.Name, "bytes_per_write", proto,
+			)
+		}
 	}
 }
 
@@ -104,25 +107,25 @@ func NewFileSystemsPerfCollector(fb *client.FBClient,
 		LatencyDesc: prometheus.NewDesc(
 			"purefb_file_systems_performance_latency_usec",
 			"FlashBlade file systems latency",
-			[]string{"name", "dimension"},
+			[]string{"name", "dimension", "protocol"},
 			prometheus.Labels{},
 		),
 		ThroughputDesc: prometheus.NewDesc(
 			"purefb_file_systems_performance_throughput_iops",
 			"FlashBlade file systems throughput",
-			[]string{"name", "dimension"},
+			[]string{"name", "dimension", "protocol"},
 			prometheus.Labels{},
 		),
 		BandwidthDesc: prometheus.NewDesc(
 			"purefb_file_systems_performance_bandwidth_bytes",
 			"FlashBlade file systems bandwidth",
-			[]string{"name", "dimension"},
+			[]string{"name", "dimension", "protocol"},
 			prometheus.Labels{},
 		),
 		AverageSizeDesc: prometheus.NewDesc(
 			"purefb_file_systems_performance_average_bytes",
 			"FlashBlade file systems average operations size",
-			[]string{"name", "dimension"},
+			[]string{"name", "dimension", "protocol"},
 			prometheus.Labels{},
 		),
 		Client:      fb,

--- a/internal/rest-client/buckets_perf.go
+++ b/internal/rest-client/buckets_perf.go
@@ -1,5 +1,9 @@
 package client
 
+import (
+	"strings"
+)
+
 type BucketsPerformanceList struct {
 	CntToken     string        `json:"continuation_token"`
 	TotalItemCnt int           `json:"total_item_count"`
@@ -13,13 +17,15 @@ func (fb *FBClient) GetBucketsPerformance(b *BucketsList) *BucketsPerformanceLis
 	if b == nil {
 		return result
 	}
-	temp := new(BucketsPerformanceList)
-	for i := 0; i < len(b.Items); i += 5 {
-		n := ""
-		for j := 0; (j < 5) && (i+j < len(b.Items)); j++ {
-			n = n + b.Items[i+j].Name + ","
+	const chunkSize = 10
+
+	for i := 0; i < len(b.Items); i += chunkSize {
+		names := make([]string, 0, chunkSize)
+		for _, bucket := range b.Items[i:min(i+chunkSize, len(b.Items))] {
+			names = append(names, bucket.Name)
 		}
-		n = n[:len(n)-1]
+		n := strings.Join(names, ",")
+		temp := new(BucketsPerformanceList)
 		res, _ := fb.RestClient.R().
 			SetResult(&temp).
 			SetQueryParam("names", n).

--- a/internal/rest-client/buckets_s3_perf.go
+++ b/internal/rest-client/buckets_s3_perf.go
@@ -1,5 +1,9 @@
 package client
 
+import (
+	"strings"
+)
+
 type BucketsS3PerformanceList struct {
 	CntToken     string          `json:"continuation_token"`
 	TotalItemCnt int             `json:"total_item_count"`
@@ -13,13 +17,15 @@ func (fb *FBClient) GetBucketsS3Performance(b *BucketsList) *BucketsS3Performanc
 	if b == nil {
 		return result
 	}
-	temp := new(BucketsS3PerformanceList)
-	for i := 0; i < len(b.Items); i += 5 {
-		n := ""
-		for j := 0; (j < 5) && (i+j < len(b.Items)); j++ {
-			n = n + b.Items[i+j].Name + ","
+	const chunkSize = 10
+
+	for i := 0; i < len(b.Items); i += chunkSize {
+		names := make([]string, 0, chunkSize)
+		for _, bucket := range b.Items[i:min(i+chunkSize, len(b.Items))] {
+			names = append(names, bucket.Name)
 		}
-		n = n[:len(n)-1]
+		n := strings.Join(names, ",")
+		temp := new(BucketsS3PerformanceList)
 		res, _ := fb.RestClient.R().
 			SetResult(&temp).
 			SetQueryParam("names", n).

--- a/internal/rest-client/filesystems_perf.go
+++ b/internal/rest-client/filesystems_perf.go
@@ -1,5 +1,7 @@
 package client
 
+import "strings"
+
 type FileSystemsPerformanceList struct {
 	CntToken     string        `json:"continuation_token"`
 	TotalItemCnt int           `json:"total_item_count"`
@@ -11,18 +13,31 @@ func (fb *FBClient) GetFileSystemsPerformance(f *FileSystemsList,
 	protocol string) *FileSystemsPerformanceList {
 	uri := "/file-systems/performance"
 	result := new(FileSystemsPerformanceList)
+	const chunkSize = 10
+
 	switch protocol {
 	case "all", "NFS", "SMB":
-		res, _ := fb.RestClient.R().
-			SetResult(&result).
-			SetQueryParam("protocol", protocol).
-			Get(uri)
-		if res.StatusCode() == 401 {
-			fb.RefreshSession()
-			fb.RestClient.R().
-				SetResult(&result).
+		for i := 0; i < len(f.Items); i += chunkSize {
+			names := make([]string, 0, chunkSize)
+			for _, fs := range f.Items[i:min(i+chunkSize, len(f.Items))] {
+				names = append(names, fs.Name)
+			}
+			n := strings.Join(names, ",")
+			temp := new(FileSystemsPerformanceList)
+			res, _ := fb.RestClient.R().
+				SetResult(&temp).
+				SetQueryParam("names", n).
 				SetQueryParam("protocol", protocol).
 				Get(uri)
+			if res.StatusCode() == 401 {
+				fb.RefreshSession()
+				fb.RestClient.R().
+					SetResult(&temp).
+					SetQueryParam("names", n).
+					SetQueryParam("protocol", protocol).
+					Get(uri)
+			}
+			result.Items = append(result.Items, temp.Items...)
 		}
 	}
 	return result

--- a/internal/rest-client/filesystems_perf.go
+++ b/internal/rest-client/filesystems_perf.go
@@ -13,27 +13,16 @@ func (fb *FBClient) GetFileSystemsPerformance(f *FileSystemsList,
 	result := new(FileSystemsPerformanceList)
 	switch protocol {
 	case "all", "NFS", "SMB":
-		temp := new(FileSystemsPerformanceList)
-		for i := 0; i < len(f.Items); i += 5 {
-			n := ""
-			for j := 0; (j < 5) && (i+j < len(f.Items)); j++ {
-				n = n + f.Items[i+j].Name + ","
-			}
-			n = n[:len(n)-1]
-			res, _ := fb.RestClient.R().
-				SetResult(&temp).
-				SetQueryParam("names", n).
+		res, _ := fb.RestClient.R().
+			SetResult(&result).
+			SetQueryParam("protocol", protocol).
+			Get(uri)
+		if res.StatusCode() == 401 {
+			fb.RefreshSession()
+			fb.RestClient.R().
+				SetResult(&result).
 				SetQueryParam("protocol", protocol).
 				Get(uri)
-			if res.StatusCode() == 401 {
-				fb.RefreshSession()
-				fb.RestClient.R().
-					SetResult(&temp).
-					SetQueryParam("names", n).
-					SetQueryParam("protocol", protocol).
-					Get(uri)
-			}
-			result.Items = append(result.Items, temp.Items...)
 		}
 	}
 	return result

--- a/internal/rest-client/filesystems_perf.go
+++ b/internal/rest-client/filesystems_perf.go
@@ -18,10 +18,10 @@ type FileSystemsPerformanceList struct {
 func (fb *FBClient) GetFileSystemsPerformance(f *FileSystemsList,
 	protocol string) *FileSystemsPerformanceList {
 	uri := "/file-systems/performance"
-	if protocol != protocolAll && protocol != protocolNFS && protocol != protocolSMB {
-		return &FileSystemsPerformanceList{}
-	}
 	result := new(FileSystemsPerformanceList)
+	if protocol != protocolAll && protocol != protocolNFS && protocol != protocolSMB {
+		return result
+	}
 	const chunkSize = 10
 
 	var filesystems []FileSystem

--- a/internal/rest-client/filesystems_perf.go
+++ b/internal/rest-client/filesystems_perf.go
@@ -2,6 +2,12 @@ package client
 
 import "strings"
 
+const (
+	protocolAll = "all"
+	protocolNFS = "NFS"
+	protocolSMB = "SMB"
+)
+
 type FileSystemsPerformanceList struct {
 	CntToken     string        `json:"continuation_token"`
 	TotalItemCnt int           `json:"total_item_count"`
@@ -12,33 +18,51 @@ type FileSystemsPerformanceList struct {
 func (fb *FBClient) GetFileSystemsPerformance(f *FileSystemsList,
 	protocol string) *FileSystemsPerformanceList {
 	uri := "/file-systems/performance"
+	if protocol != protocolAll && protocol != protocolNFS && protocol != protocolSMB {
+		return &FileSystemsPerformanceList{}
+	}
 	result := new(FileSystemsPerformanceList)
 	const chunkSize = 10
 
+	var filesystems []FileSystem
 	switch protocol {
-	case "all", "NFS", "SMB":
-		for i := 0; i < len(f.Items); i += chunkSize {
-			names := make([]string, 0, chunkSize)
-			for _, fs := range f.Items[i:min(i+chunkSize, len(f.Items))] {
-				names = append(names, fs.Name)
+	case protocolNFS:
+		for _, fs := range f.Items {
+			if fs.Nfs.V3Enabled || fs.Nfs.V41Enabled {
+				filesystems = append(filesystems, fs)
 			}
-			n := strings.Join(names, ",")
-			temp := new(FileSystemsPerformanceList)
-			res, _ := fb.RestClient.R().
+		}
+	case protocolSMB:
+		for _, fs := range f.Items {
+			if fs.Smb.Enabled {
+				filesystems = append(filesystems, fs)
+			}
+		}
+	case protocolAll:
+		filesystems = f.Items
+	}
+
+	for i := 0; i < len(filesystems); i += chunkSize {
+		names := make([]string, 0, chunkSize)
+		for _, fs := range filesystems[i:min(i+chunkSize, len(filesystems))] {
+			names = append(names, fs.Name)
+		}
+		n := strings.Join(names, ",")
+		temp := new(FileSystemsPerformanceList)
+		res, _ := fb.RestClient.R().
+			SetResult(&temp).
+			SetQueryParam("names", n).
+			SetQueryParam("protocol", protocol).
+			Get(uri)
+		if res.StatusCode() == 401 {
+			fb.RefreshSession()
+			fb.RestClient.R().
 				SetResult(&temp).
 				SetQueryParam("names", n).
 				SetQueryParam("protocol", protocol).
 				Get(uri)
-			if res.StatusCode() == 401 {
-				fb.RefreshSession()
-				fb.RestClient.R().
-					SetResult(&temp).
-					SetQueryParam("names", n).
-					SetQueryParam("protocol", protocol).
-					Get(uri)
-			}
-			result.Items = append(result.Items, temp.Items...)
 		}
+		result.Items = append(result.Items, temp.Items...)
 	}
 	return result
 }


### PR DESCRIPTION
Fixes #117 

I mostly just mimicked what was already being done for the array perf metrics where we were presenting out a metric for each protocol and the cumulative metric under protocol "all". 