### PR TITLE
usage_collector.go: set quota to default quota for filesystem if unset

### DIFF
--- a/internal/openmetrics-exporter/usage_collector.go
+++ b/internal/openmetrics-exporter/usage_collector.go
@@ -26,10 +26,16 @@ func (c *UsageCollector) Collect(ch chan<- prometheus.Metric) {
 	if len(uusers.Items) > 0 {
 		for _, usage := range uusers.Items {
 			uid = strconv.Itoa(usage.User.Id)
+			// Set quotaValue to the quota
+			quotaValue := usage.Quota
+			// if the quota is 0 though, set it to the default quota for users on the filesystem
+			if usage.Quota == 0 {
+				quotaValue = usage.FileSystemDefaultQuota
+			}
 			ch <- prometheus.MustNewConstMetric(
 				c.UsageUsersDesc,
 				prometheus.GaugeValue,
-				usage.Quota,
+				quotaValue,
 				usage.FileSystem.Name, usage.User.Name, uid, "quota",
 			)
 			ch <- prometheus.MustNewConstMetric(
@@ -44,10 +50,16 @@ func (c *UsageCollector) Collect(ch chan<- prometheus.Metric) {
 	if len(ugroups.Items) > 0 {
 		for _, usage := range ugroups.Items {
 			gid = strconv.Itoa(usage.Group.Id)
+			// Set quotaValue to the quota
+			quotaValue := usage.Quota
+			// if the quota is 0 though, set it to the default quota for users on the filesystem
+			if usage.Quota == 0 {
+				quotaValue = usage.FileSystemDefaultQuota
+			}
 			ch <- prometheus.MustNewConstMetric(
 				c.UsageGroupsDesc,
 				prometheus.GaugeValue,
-				usage.Quota,
+				quotaValue,
 				usage.FileSystem.Name, usage.Group.Name, gid, "quota",
 			)
 			ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Change the usage quota reported to show the default for the filesystem, if set to 0 in the user's own, to allow the quota metric to be reported for users without a specific quota set.

I don't know if this should be implemented like I've done here in the pull request, or added as a third `dimension` so that both the default quota for the filesystem and the specific quota for a user can be seen - I guess the way as implemented may be somewhat disruptive to users of the current metric, but it is currently displayed as 0 unless specifically set, and I'm not sure how useful that is.

Also, I don't know if it's possible to manually set a quota for a user to 0, if it is then in this implementation it may be erroneous to show it as the default quota.