### PR TITLE
Split user and group usage into two collectors

### DIFF
--- a/internal/openmetrics-exporter/collector.go
+++ b/internal/openmetrics-exporter/collector.go
@@ -65,8 +65,12 @@ func Collector(ctx context.Context, metrics string, registry *prometheus.Registr
 	}
 	if metrics == "all" || metrics == "usage" {
 		filesystems := fbclient.GetFileSystems()
-		usageCollector := NewUsageCollector(fbclient, filesystems)
-		registry.MustRegister(usageCollector)
+		usageUserCollector := NewUsageUserCollector(fbclient, filesystems)
+		usageGroupCollector := NewUsageGroupCollector(fbclient, filesystems)
+		registry.MustRegister(
+			usageUserCollector,
+			usageGroupCollector,
+		)
 	}
 	if metrics == "all" || metrics == "policies" {
 		policiesCollector := NewNfsPoliciesCollector(fbclient)

--- a/internal/openmetrics-exporter/usage_group_collector.go
+++ b/internal/openmetrics-exporter/usage_group_collector.go
@@ -7,39 +7,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type UsageCollector struct {
-	UsageUsersDesc  *prometheus.Desc
+type UsageGroupCollector struct {
 	UsageGroupsDesc *prometheus.Desc
 	Client          *client.FBClient
 	FileSystems     *client.FileSystemsList
 }
 
-func (c *UsageCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.UsageUsersDesc
+func (c *UsageGroupCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.UsageGroupsDesc
 }
 
-func (c *UsageCollector) Collect(ch chan<- prometheus.Metric) {
-	uid := ""
+func (c *UsageGroupCollector) Collect(ch chan<- prometheus.Metric) {
 	gid := ""
-	uusers := c.Client.GetUsageUsers(c.FileSystems)
-	if len(uusers.Items) > 0 {
-		for _, usage := range uusers.Items {
-			uid = strconv.Itoa(usage.User.Id)
-			ch <- prometheus.MustNewConstMetric(
-				c.UsageUsersDesc,
-				prometheus.GaugeValue,
-				usage.Quota,
-				usage.FileSystem.Name, usage.User.Name, uid, "quota",
-			)
-			ch <- prometheus.MustNewConstMetric(
-				c.UsageUsersDesc,
-				prometheus.GaugeValue,
-				usage.Usage,
-				usage.FileSystem.Name, usage.User.Name, uid, "usage",
-			)
-		}
-	}
 	ugroups := c.Client.GetUsageGroups(c.FileSystems)
 	if len(ugroups.Items) > 0 {
 		for _, usage := range ugroups.Items {
@@ -60,15 +39,9 @@ func (c *UsageCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func NewUsageCollector(fb *client.FBClient,
-	f *client.FileSystemsList) *UsageCollector {
-	return &UsageCollector{
-		UsageUsersDesc: prometheus.NewDesc(
-			"purefb_file_system_usage_users_bytes",
-			"FlashBlade file system users usage",
-			[]string{"file_system", "user_name", "id", "dimension"},
-			prometheus.Labels{},
-		),
+func NewUsageGroupCollector(fb *client.FBClient,
+	f *client.FileSystemsList) *UsageGroupCollector {
+	return &UsageGroupCollector{
 		UsageGroupsDesc: prometheus.NewDesc(
 			"purefb_file_system_usage_groups_bytes",
 			"FlashBlade file system groups usage",

--- a/internal/openmetrics-exporter/usage_user_collector.go
+++ b/internal/openmetrics-exporter/usage_user_collector.go
@@ -1,0 +1,54 @@
+package collectors
+
+import (
+	client "purestorage/fb-openmetrics-exporter/internal/rest-client"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type UsageUserCollector struct {
+	UsageUsersDesc *prometheus.Desc
+	Client         *client.FBClient
+	FileSystems    *client.FileSystemsList
+}
+
+func (c *UsageUserCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.UsageUsersDesc
+}
+
+func (c *UsageUserCollector) Collect(ch chan<- prometheus.Metric) {
+	uid := ""
+	uusers := c.Client.GetUsageUsers(c.FileSystems)
+	if len(uusers.Items) > 0 {
+		for _, usage := range uusers.Items {
+			uid = strconv.Itoa(usage.User.Id)
+			ch <- prometheus.MustNewConstMetric(
+				c.UsageUsersDesc,
+				prometheus.GaugeValue,
+				usage.Quota,
+				usage.FileSystem.Name, usage.User.Name, uid, "quota",
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.UsageUsersDesc,
+				prometheus.GaugeValue,
+				usage.Usage,
+				usage.FileSystem.Name, usage.User.Name, uid, "usage",
+			)
+		}
+	}
+}
+
+func NewUsageUserCollector(fb *client.FBClient,
+	f *client.FileSystemsList) *UsageUserCollector {
+	return &UsageUserCollector{
+		UsageUsersDesc: prometheus.NewDesc(
+			"purefb_file_system_usage_users_bytes",
+			"FlashBlade file system users usage",
+			[]string{"file_system", "user_name", "id", "dimension"},
+			prometheus.Labels{},
+		),
+		Client:      fb,
+		FileSystems: f,
+	}
+}

--- a/internal/rest-client/usage.go
+++ b/internal/rest-client/usage.go
@@ -1,5 +1,7 @@
 package client
 
+import "sync"
+
 type Group struct {
 	Id   int    `json:"id"`
 	Name string `json:"name"`
@@ -49,19 +51,30 @@ type UsageUsersList struct {
 func (fb *FBClient) GetUsageUsers(f *FileSystemsList) *UsageUsersList {
 	uri := "/usage/users"
 	result := new(UsageUsersList)
-	temp := new(UsageUsersList)
-	for i := 0; i < len(f.Items); i++ {
-		res, _ := fb.RestClient.R().
-			SetResult(&temp).
-			SetQueryParam("file_system_ids", f.Items[i].Id).
-			Get(uri)
-		if res.StatusCode() == 401 {
-			fb.RefreshSession()
-			fb.RestClient.R().
+	var wg sync.WaitGroup
+	outputChan := make(chan *UsageUsersList, len(f.Items))
+	for _, fs := range f.Items {
+		wg.Add(1)
+		go func(fs *FileSystem) {
+			defer wg.Done()
+			temp := new(UsageUsersList)
+			res, _ := fb.RestClient.R().
 				SetResult(&temp).
-				SetQueryParam("file_system_ids", f.Items[i].Id).
+				SetQueryParam("file_system_ids", fs.Id).
 				Get(uri)
-		}
+			if res.StatusCode() == 401 {
+				fb.RefreshSession()
+				fb.RestClient.R().
+					SetResult(&temp).
+					SetQueryParam("file_system_ids", fs.Id).
+					Get(uri)
+			}
+			outputChan <- temp
+		}(&fs)
+	}
+	wg.Wait()
+	close(outputChan)
+	for temp := range outputChan {
 		result.Items = append(result.Items, temp.Items...)
 	}
 	return result
@@ -70,19 +83,30 @@ func (fb *FBClient) GetUsageUsers(f *FileSystemsList) *UsageUsersList {
 func (fb *FBClient) GetUsageGroups(f *FileSystemsList) *UsageGroupsList {
 	uri := "/usage/groups"
 	result := new(UsageGroupsList)
-	temp := new(UsageGroupsList)
-	for i := 0; i < len(f.Items); i++ {
-		res, _ := fb.RestClient.R().
-			SetResult(&temp).
-			SetQueryParam("file_system_ids", f.Items[i].Id).
-			Get(uri)
-		if res.StatusCode() == 401 {
-			fb.RefreshSession()
-			fb.RestClient.R().
+	var wg sync.WaitGroup
+	outputChan := make(chan *UsageGroupsList, len(f.Items))
+	for _, fs := range f.Items {
+		wg.Add(1)
+		go func(fs *FileSystem) {
+			defer wg.Done()
+			temp := new(UsageGroupsList)
+			res, _ := fb.RestClient.R().
 				SetResult(&temp).
-				SetQueryParam("file_system_ids", f.Items[i].Id).
+				SetQueryParam("file_system_ids", fs.Id).
 				Get(uri)
-		}
+			if res.StatusCode() == 401 {
+				fb.RefreshSession()
+				fb.RestClient.R().
+					SetResult(&temp).
+					SetQueryParam("file_system_ids", fs.Id).
+					Get(uri)
+			}
+			outputChan <- temp
+		}(&fs)
+	}
+	wg.Wait()
+	close(outputChan)
+	for temp := range outputChan {
 		result.Items = append(result.Items, temp.Items...)
 	}
 	return result


### PR DESCRIPTION
Fixes #126

I made two commits for this.

The first commit in this branch only splits the user and group usage into two collectors. This allows them to run simultaneously resulting in roughly a 50% reduction in collection time. While this solves my immediate issue, it does just kick the can down the road a bit.

The second commit wraps the REST calls in a go func. This allows the individual calls within each collector to run simultaneously. This resulted in a further 60% reduction in collection time for a total reduction of about 80% of the runtime. 

I see 2 potential downsides with the second commit. The first is that it is a break from the norm of how the rest of collectors are setup. That said, this may be something that we want to further implement in other places. 

The second downside is that currently, the `MaxConnsPerHost` doesn't appear to be set within the code or within Resty. This would result in a higher amount of concurrent REST API calls to the FlashBlade which could result in 429 errors. Resty does implement an incremental backoff with retries, but overall this could result in an overall longer collection period. In my testing, I haven't run into this, but wanted to bring it up as a potential impact of this change. 